### PR TITLE
saving and loading cache, using workspace to save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,6 +1202,18 @@
         "ws": "^7.0.0"
       }
     },
+    "@jupyterlab/statedb": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-3.2.9.tgz",
+      "integrity": "sha512-BmH/f1n8LwHjAifSg76lxYs70yioWapfOrA9PEh10nDbgmZiQXbNpcsaToJkI6e27NcADmomi4Aj637TLCDbCg==",
+      "requires": {
+        "@lumino/commands": "^1.12.0",
+        "@lumino/coreutils": "^1.5.3",
+        "@lumino/disposable": "^1.4.3",
+        "@lumino/properties": "^1.2.3",
+        "@lumino/signaling": "^1.4.3"
+      }
+    },
     "@jupyterlab/statusbar": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
@@ -1236,6 +1248,70 @@
         "@phosphor/widgets": "^1.9.0",
         "react": "~16.8.4",
         "typestyle": "^2.0.1"
+      }
+    },
+    "@lumino/algorithm": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.9.1.tgz",
+      "integrity": "sha512-d0rj7IYRzYj6WbWSrbJbKvrfO4H0NUnXT2yjSWS/sCklpTpSp0IGmndK/X4r6gG+ev5lb5+wBg9ofUDBvoAlAw=="
+    },
+    "@lumino/commands": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.20.0.tgz",
+      "integrity": "sha512-xyrzDIJ9QEbcbRAwmXrjb7A7/E5MDNbnLANKwqmFVNF+4LSnF62obdvY4On3Rify3HmfX0u16Xr9gfoWPX9wLQ==",
+      "requires": {
+        "@lumino/algorithm": "^1.9.1",
+        "@lumino/coreutils": "^1.12.0",
+        "@lumino/disposable": "^1.10.1",
+        "@lumino/domutils": "^1.8.1",
+        "@lumino/keyboard": "^1.8.1",
+        "@lumino/signaling": "^1.10.1",
+        "@lumino/virtualdom": "^1.14.1"
+      }
+    },
+    "@lumino/coreutils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.12.0.tgz",
+      "integrity": "sha512-DSglh4ylmLi820CNx9soJmDJCpUgymckdWeGWuN0Ash5g60oQvrQDfosVxEhzmNvtvXv45WZEqSBzDP6E5SEmQ=="
+    },
+    "@lumino/disposable": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.10.1.tgz",
+      "integrity": "sha512-mZQILc8sVGZC7mJNOGVmehDRO9/u3sIRdjZ+pCYjDgXKcINLd6HoPhZDquKCWiRBfHTL1B3tOHjnBhahBc2N/Q==",
+      "requires": {
+        "@lumino/algorithm": "^1.9.1",
+        "@lumino/signaling": "^1.10.1"
+      }
+    },
+    "@lumino/domutils": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.8.1.tgz",
+      "integrity": "sha512-QUVXwmDMIfcHC3yslhmyGK4HYBKaJ3xX5MTwDrjsSX7J7AZ4jwL4zfsxyF9ntdqEKraoJhLQ6BaUBY+Ur1cnYw=="
+    },
+    "@lumino/keyboard": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.8.1.tgz",
+      "integrity": "sha512-8x0y2ZQtEvOsblpI2gfTgf+gboftusP+5aukKEsgNQtzFl28RezQXEOSVd8iD3K6+Q1MaPQF0OALYP0ASqBjBg=="
+    },
+    "@lumino/properties": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.8.1.tgz",
+      "integrity": "sha512-O+CCcAqP64Di32DUZ4Jqq0DtUyE5RJREN5vbkgGZGu+WauJ/RYoiLDe1ubbAeSaHk71OrS60ZBV7QyC8ZaBVsA=="
+    },
+    "@lumino/signaling": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.10.1.tgz",
+      "integrity": "sha512-GZVbX4cfk/ZqLwkemPD/NwqToaTL/6q7qdLpEhgkiPlaH1S5/V7fDpP7N1uFy4n3BDITId8cpYgH/Ds32Mdp3A==",
+      "requires": {
+        "@lumino/algorithm": "^1.9.1"
+      }
+    },
+    "@lumino/virtualdom": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.14.1.tgz",
+      "integrity": "sha512-imIJd/wtRkoR1onEiG5nxPEaIrf70nn4PgD/56ri3/Lo6AJEX2CusF6iIA27GVB8yl/7CxgTHUnzzCwTFPypcA==",
+      "requires": {
+        "@lumino/algorithm": "^1.9.1"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
+    "@blockly/block-plus-minus": "3.0.6",
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/apputils": "^1.2.1",
     "@jupyterlab/notebook": "^1.2.2",
+    "@jupyterlab/statedb": "^3.2.9",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/widgets": "^1.9.3",
-    "blockly": "^3.20191014.4",
-    "@blockly/block-plus-minus": "3.0.6"
+    "blockly": "^3.20191014.4"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",

--- a/src/JupyterlabCoreutils.fs
+++ b/src/JupyterlabCoreutils.fs
@@ -1233,6 +1233,11 @@ module Statedb =
 
     type [<AllowNullLiteral>] IExports =
         abstract StateDB: StateDBStatic
+        abstract IStateDB: Tokens.IStateDB //AO: 2/27/22
+
+    //AO: 2/27/22
+    [<Import("*","@jupyterlab/coreutils")>]
+    let Types : IExports = jsNative
 
     type StateDB =
         StateDB<obj>


### PR DESCRIPTION
- Uses StateDB to save intellisense variables in workspace
- Loads this cache on start up
- Saves to this cache every ~2 minutes
- Dirtiness of cache is checked by querying variable against stored variable and ensuring their info matches; if not, variable is updated in cache
- Checkbox UI for controling cache
    - Enabled by default
    - Unchecking causes a workspace reset (total, so all state not just cache)
    - If checked on startup and workspace not in URL, changes URL and reloads page to load cache